### PR TITLE
#103 Functionality for Custom Preferences implemented

### DIFF
--- a/source/packages/logger.pks
+++ b/source/packages/logger.pks
@@ -233,6 +233,12 @@ as
     $END
     ;
 
+   --#103
+   procedure set_cust_pref (
+      p_pref_name in logger_prefs.pref_name%type,
+      p_pref_value in logger_prefs.pref_value%type
+   );
+
 	procedure purge(
 		p_purge_after_days in varchar2 default null,
 		p_purge_min_level	in varchar2	default null);

--- a/source/tables/logger_prefs.sql
+++ b/source/tables/logger_prefs.sql
@@ -55,6 +55,26 @@ begin
       :new.pref_value := 'NONE';
     end if;
 
+    -- #103
+    -- Only predefined preferences and Custom Preferences are allowed
+    -- Custom Preferences must be prefixed with CUST_
+    if substr (:new.pref_name, 1, 5) <> 'CUST_'
+    and :new.pref_name not in ('GLOBAL_CONTEXT_NAME'
+                           ,'INCLUDE_CALL_STACK'
+                           ,'INSTALL_SCHEMA'
+                           ,'LEVEL'
+                           ,'LOGGER_DEBUG'
+                           ,'LOGGER_VERSION'
+                           ,'PLUGIN_FN_ERROR'
+                           ,'PREF_BY_CLIENT_ID_EXPIRE_HOURS'
+                           ,'PROTECT_ADMIN_PROCS'
+                           ,'PURGE_AFTER_DAYS'
+                           ,'PURGE_MIN_LEVEL'
+                           )
+    then
+       raise_application_error (-20000, 'Only Predefined Preferences and Custom Preferences that begin with "CUST_" are allowed');
+    end if;
+
     -- this is because the logger package is not installed yet.  We enable it in logger_configure
     logger.null_global_contexts;
   $end


### PR DESCRIPTION
Custom Preferences can be set through the ```sql set_cust_pref ``` procedure, and they can be removed by providing a NULL for the ```sql pref_value ```. Validation is added that Custom Preferences begin with "CUST_".
Table trigger ensures that only the predefined preferences can be set or that the Custom Preferences begin with "CUST_"