### PR TITLE
Update logger_prefs.sql

### DIFF
--- a/source/tables/logger_prefs.sql
+++ b/source/tables/logger_prefs.sql
@@ -259,7 +259,7 @@ begin
   set
     pref_name = upper(pref_name),
     pref_type = upper(pref_type)
-  where 1=1
+  where 1=0
     or pref_name != upper(pref_name)
     or pref_type != upper(pref_type);
 


### PR DESCRIPTION
When you have only OR in a where-clause, the (dummy) first clause should not be "1=1" (always TRUE, like used when the where-clause is composed of ANDs), but "1=0" to have an always FALSE to start out with.

Currently, ALL records of logger_prefs are updated. With this bug, to much work is performed, but the result is fortunately the same (supposing there are no active triggers on that table).