### PR TITLE
Use level setting per scope

### DIFF
--- a/source/jobs/logger_unset_prefs_by_scope.sql
+++ b/source/jobs/logger_unset_prefs_by_scope.sql
@@ -1,0 +1,22 @@
+declare
+  l_count pls_integer;
+  l_job_name user_scheduler_jobs.job_name%type := 'LOGGER_UNSET_PREFS_BY_SCOPE';
+begin
+  
+  select count(1)
+  into l_count
+  from user_scheduler_jobs
+  where job_name = l_job_name;
+  
+  if l_count = 0 then
+    dbms_scheduler.create_job(
+       job_name => l_job_name,
+       job_type => 'PLSQL_BLOCK',
+       job_action => 'begin logger.unset_scope_level; end; ',
+       start_date => systimestamp,
+       repeat_interval => 'FREQ=HOURLY; BYHOUR=1',
+       enabled => TRUE,
+       comments => 'Clears expired logger prefs by scope');
+  end if;
+end;
+/

--- a/source/scripts/create_logger_public_synonyms.sql
+++ b/source/scripts/create_logger_public_synonyms.sql
@@ -1,0 +1,23 @@
+-- Creates public synonyms from defined user for Logger objects
+
+
+set define '&'
+set verify off
+
+-- Parameters
+define from_user=LOGGER_USER
+accept from_user char default &from_user prompt 'Name of the logger schema [&from_user] :'
+
+
+whenever sqlerror exit sql.sqlcode
+
+create or replace public synonym logger for &from_user..logger;
+create or replace public synonym logger_logs for &from_user..logger_logs;
+create or replace public synonym logger_logs_apex_items for &from_user..logger_logs_apex_items;
+create or replace public synonym logger_prefs for &from_user..logger_prefs;
+create or replace public synonym logger_prefs_by_client_id for &from_user..logger_prefs_by_client_id;
+create or replace public synonym logger_logs_5_min for &from_user..logger_logs_5_min;
+create or replace public synonym logger_logs_60_min for &from_user..logger_logs_60_min;
+create or replace public synonym logger_logs_terse for &from_user..logger_logs_terse;
+-- PBA/MNU 3.1.2
+create or replace public synonym logger_prefs_by_scope for &from_user..logger_prefs_by_scope;

--- a/source/scripts/create_logger_synonyms.sql
+++ b/source/scripts/create_logger_synonyms.sql
@@ -15,3 +15,5 @@ create or replace synonym logger_prefs_by_client_id for &from_user..logger_prefs
 create or replace synonym logger_logs_5_min for &from_user..logger_logs_5_min;
 create or replace synonym logger_logs_60_min for &from_user..logger_logs_60_min;
 create or replace synonym logger_logs_terse for &from_user..logger_logs_terse;
+-- PBA/MNU 3.1.2
+create or replace synonym logger_prefs_by_scope for &from_user..logger_prefs_by_scope;

--- a/source/scripts/grant_logger_to_public.sql
+++ b/source/scripts/grant_logger_to_public.sql
@@ -1,0 +1,18 @@
+-- Grants privileges for logger objects from current user to public
+
+
+-- Parameters
+-- none
+
+whenever sqlerror exit sql.sqlcode
+
+grant execute on logger to public;
+grant select, delete on logger_logs to public;
+grant select on logger_logs_apex_items to public;
+grant select, update on logger_prefs to public;
+grant select on logger_prefs_by_client_id to public;
+grant select on logger_logs_5_min to public;
+grant select on logger_logs_60_min to public;
+grant select on logger_logs_terse to public;
+-- PBA/MNU 3.1.2
+grant select, insert, update, delete on logger_prefs_by_scope to public;

--- a/source/scripts/grant_logger_to_user.sql
+++ b/source/scripts/grant_logger_to_user.sql
@@ -15,3 +15,6 @@ grant select on logger_prefs_by_client_id to &to_user;
 grant select on logger_logs_5_min to &to_user;
 grant select on logger_logs_60_min to &to_user;
 grant select on logger_logs_terse to &to_user;
+-- PBA/MNU 3.1.2
+grant select, insert, update, delete on logger_prefs_by_scope to &to_user;
+

--- a/source/tables/logger_prefs_by_scope.sql
+++ b/source/tables/logger_prefs_by_scope.sql
@@ -1,0 +1,44 @@
+-- Initial table script built from 3.1.2
+declare
+  l_count pls_integer;
+
+begin
+  -- Create Table
+  select count(1)
+  into l_count
+  from user_tables
+  where table_name = 'LOGGER_PREFS_BY_SCOPE';
+
+  if l_count = 0 then
+    execute immediate q'!
+create table logger_prefs_by_scope(
+  logger_scope      varchar2(512) not null,
+  logger_level      varchar2(20) not null,
+  created_date      date default sysdate not null,
+  expiry_date       date default sysdate+1/24 not null,
+  constraint logger_prefs_by_scope_pk primary key (logger_scope) enable,
+  constraint logger_prefs_by_scope_ck1 check (logger_level in ('OFF','PERMANENT','ERROR','WARNING','INFORMATION','DEBUG','TIMING', 'APEX', 'SYS_CONTEXT')),
+  constraint logger_prefs_by_scope_ck2 check (expiry_date >= created_date)
+)!';
+  end if;
+
+-- Add comments to the table 
+  execute immediate q'!comment on table LOGGER_PREFS_BY_SCOPE is 'Scope specific logger levels. Only active scopes/logger_levels will be maintained in this table'!';
+-- Add comments to the columns 
+  execute immediate q'!comment on column LOGGER_PREFS_BY_SCOPE.LOGGER_SCOPE is 'Scope. Wildcards allowed. Interpreted as LIKE pattern'!';
+  execute immediate q'!comment on column LOGGER_PREFS_BY_SCOPE.LOGGER_LEVEL is 'Logger level. Must be OFF, PERMANENT, ERROR, WARNING, INFORMATION, DEBUG, TIMING'!';
+  execute immediate q'!comment on column LOGGER_PREFS_BY_SCOPE.CREATED_DATE is 'Date that entry was created on'!';
+  execute immediate q'!comment on column LOGGER_PREFS_BY_SCOPE.expiry_date is 'After the given expiry date the logger_level will be disabled for the specific client_id. Unless sepcifically removed from this table a job will clean up old entries'!';
+end;
+/
+create or replace trigger biu_logger_prefs_by_scope
+  before insert or update on logger_prefs_by_scope 
+  for each row
+begin
+  $if $$logger_no_op_install $then
+    null;
+  $else
+    :new.logger_scope := lower(:new.logger_scope);
+  $end
+end biu_logger_prefs_by_scope;
+/


### PR DESCRIPTION
The log level can be set per scope. This specific log level will be used regardsless of the main log level. The specific log level can be higher or lower than the generic level